### PR TITLE
fix: v1.1.1 — report window blur as background on web & desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## 1.1.1
+
+- Web & desktop: window **blur** (lost focus) is now reported as `background`
+  and window **focus** as `foreground` — previously a blurred-but-visible
+  window was missed. Mobile behavior is unchanged.
+
 ## 1.1.0
 
 - **Web & desktop support** — foreground/background and idle now work on web,

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Helpers on each status: `isOnline`, `isOffline`, `isIdle`, `isLocked`,
 | iOS | ✅ | ✅ (data-protection APIs) |
 | Web · macOS · Windows · Linux | ✅ | — |
 
+On web and desktop, `foreground`/`background` reflect window **focus/blur**
+(a focused window is online, a blurred or minimized one is offline) — there is
+no device-lock concept there.
+
 ## Install
 
 ```yaml

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = "com.example.unlock_detector"
-version = "1.1.0"
+version = "1.1.1"
 
 buildscript {
     ext.kotlin_version = "2.3.21"

--- a/ios/unlock_detector.podspec
+++ b/ios/unlock_detector.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'unlock_detector'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'Flutter plugin for detecting device lock/unlock and app foreground/background events.'
   s.description      = <<-DESC
 A Flutter plugin that detects device lock/unlock and app foreground/background

--- a/lib/unlock_detector.dart
+++ b/lib/unlock_detector.dart
@@ -2,8 +2,10 @@
 /// state — for user online/offline presence.
 ///
 /// Platform coverage:
-/// - **foreground / background / idle** — all platforms (Android, iOS, web,
-///   macOS, Windows, Linux), driven by the Flutter app lifecycle.
+/// - **foreground / background / idle** — all platforms. On Android and iOS
+///   this tracks the app lifecycle; on web and desktop it tracks window
+///   focus/blur (a focused window is `foreground`, a blurred or minimized
+///   one is `background`).
 /// - **locked / unlocked / screenOn** — Android and iOS only.
 library;
 
@@ -270,23 +272,40 @@ class UnlockDetector {
       return 'iOS: foreground/background and idle detection; lock/unlock via '
           'data-protection APIs (works while the app is active).';
     }
-    return 'Web / desktop: foreground/background and idle detection.';
+    return 'Web / desktop: window focus/blur (foreground/background) and idle '
+        'detection.';
   }
 
   // --- internals ---
 
+  /// Whether the app runs on web or a desktop OS, where presence is a matter
+  /// of window focus rather than device lock.
+  static bool get _isDesktopOrWeb =>
+      kIsWeb ||
+      defaultTargetPlatform == TargetPlatform.macOS ||
+      defaultTargetPlatform == TargetPlatform.windows ||
+      defaultTargetPlatform == TargetPlatform.linux;
+
   static void _onLifecycleStateChange(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
+        // Window focused / app in the foreground.
         _emit(UnlockDetectorStatus.foreground);
         _armIdleTimer();
       case AppLifecycleState.paused:
       case AppLifecycleState.hidden:
       case AppLifecycleState.detached:
+        // App hidden / window minimized.
         _idleTimer?.cancel();
         _emit(UnlockDetectorStatus.background);
       case AppLifecycleState.inactive:
-        break; // transitional — ignore
+        // On web and desktop, 'inactive' means the window lost focus — treat
+        // it as background. On mobile it is only a brief transition (incoming
+        // call, app switcher, control center), so it is ignored there.
+        if (_isDesktopOrWeb) {
+          _idleTimer?.cancel();
+          _emit(UnlockDetectorStatus.background);
+        }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: unlock_detector
 description: "A Flutter plugin to detect device lock/unlock and app foreground/background events for user online/offline presence."
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/mustafa-707/unlock_detector
 issue_tracker: https://github.com/mustafa-707/unlock_detector/issues
 


### PR DESCRIPTION
## Summary

On web and desktop, `AppLifecycleState.inactive` means the window **lost focus**. v1.1.0 ignored it, so a blurred-but-still-visible window stayed `foreground`.

Now web/desktop report window **blur → `background`** and window **focus → `foreground`** — proper window-focus presence. Mobile is unchanged (`inactive` stays a transient state there).

- `getPlatformInfo()` and docs updated to describe web/desktop as window focus/blur.
- Version → 1.1.1.

## Verification

- ✅ Web builds
- ✅ macOS builds
- ✅ `dart analyze` clean, `dart format` clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)