### PR TITLE
feat: v1.2.0 — native desktop folders + system-wide idle detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ migrate_working_dir/
 **/doc/api/
 .dart_tool/
 build/
+
+# AI tooling
+.claude/
+.claude-flow/
+.mcp.json

--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "761747bfc538b5af34aa0d3fac380f1bc331ec49"
+  revision: "559ffa3f75e7402d65a8def9c28389a9b2e6fe42"
   channel: "stable"
 
 project_type: plugin
@@ -13,14 +13,26 @@ project_type: plugin
 migration:
   platforms:
     - platform: root
-      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
-      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: android
-      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
-      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
     - platform: ios
-      create_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
-      base_revision: 761747bfc538b5af34aa0d3fac380f1bc331ec49
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+    - platform: linux
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+    - platform: macos
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+    - platform: web
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+    - platform: windows
+      create_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
+      base_revision: 559ffa3f75e7402d65a8def9c28389a9b2e6fe42
 
   # User provided section
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGES
 
+## 1.2.0
+
+- **Native desktop support** — macOS, Windows and Linux now ship native plugin
+  code with **system-wide idle detection**: when `initialize()` is given an
+  `idleTimeout`, the `idle` status follows the OS idle time (time since any
+  keyboard/mouse input) — no `reportActivity()` needed on desktop.
+  - macOS: IOKit HID idle time · Windows: `GetLastInputInfo` · Linux: the X11
+    screensaver extension (needs `libxss-dev`; X11 sessions).
+- All six platforms are now declared with native implementations in `pubspec.yaml`.
+
 ## 1.1.1
 
 - Web & desktop: window **blur** (lost focus) is now reported as `background`

--- a/README.md
+++ b/README.md
@@ -22,15 +22,17 @@ Helpers on each status: `isOnline`, `isOffline`, `isIdle`, `isLocked`,
 
 ## Platform support
 
-| Platform | foreground / background / idle | lock / unlock |
-| -------- | :---: | :---: |
-| Android | ✅ | ✅ + `screenOn` |
-| iOS | ✅ | ✅ (data-protection APIs) |
-| Web · macOS · Windows · Linux | ✅ | — |
+| Platform | foreground / background | idle | lock / unlock |
+| -------- | :---: | :---: | :---: |
+| Android | ✅ | ✅ in-app | ✅ + `screenOn` |
+| iOS | ✅ | ✅ in-app | ✅ (data-protection APIs) |
+| macOS · Windows · Linux | ✅ window focus | ✅ OS system-wide | — |
+| Web | ✅ window focus | ✅ in-app | — |
 
 On web and desktop, `foreground`/`background` reflect window **focus/blur**
-(a focused window is online, a blurred or minimized one is offline) — there is
-no device-lock concept there.
+(a focused window is online, blurred or minimized is offline) — there is no
+device-lock concept there. On desktop, `idle` follows the **OS system-wide**
+idle time; on mobile and web it follows in-app interaction (see below).
 
 ## Install
 
@@ -73,13 +75,16 @@ await UnlockDetector.dispose();
 
 ### Idle detection
 
-When you pass `idleTimeout`, feed user interaction so the timer can reset —
-either call `UnlockDetector.reportActivity()` from your input handling, or wrap
-your app:
+Pass `idleTimeout` to `initialize()` to get the `idle` status.
 
-```dart
-runApp(UnlockDetector.activityDetector(child: const MyApp()));
-```
+- **Desktop (macOS/Windows/Linux):** automatic — idle follows the OS
+  system-wide idle time (any keyboard/mouse input). Nothing else to do.
+- **Mobile & web:** feed in-app interaction so the timer can reset — call
+  `UnlockDetector.reportActivity()` from your input handling, or wrap your app:
+
+  ```dart
+  runApp(UnlockDetector.activityDetector(child: const MyApp()));
+  ```
 
 Initialization failures throw `UnlockDetectorException`. Call
 `UnlockDetector.getPlatformInfo()` for a description of platform behavior.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group = "com.example.unlock_detector"
-version = "1.1.1"
+version = "1.2.0"
 
 buildscript {
     ext.kotlin_version = "2.3.21"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Flutter (1.0.0)
-  - unlock_detector (1.1.0):
+  - unlock_detector (1.2.0):
     - Flutter
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  unlock_detector: 8ceb09008d1fb916cdeba493593f9b9802b60626
+  unlock_detector: be0e0edf6db44b0c5bf854f743147f6c4f45a78c
 
 PODFILE CHECKSUM: 4f1c12611da7338d21589c0b2ecd6bd20b109694
 

--- a/example/ios/Runner/SceneDelegate.swift
+++ b/example/ios/Runner/SceneDelegate.swift
@@ -1,0 +1,6 @@
+import Flutter
+import UIKit
+
+class SceneDelegate: FlutterSceneDelegate {
+
+}

--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <unlock_detector/unlock_detector_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) unlock_detector_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UnlockDetectorPlugin");
+  unlock_detector_plugin_register_with_registrar(unlock_detector_registrar);
 }

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  unlock_detector
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import unlock_detector
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  UnlockDetectorPlugin.register(with: registry.registrar(forPlugin: "UnlockDetectorPlugin"))
 }

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,15 +1,21 @@
 PODS:
   - FlutterMacOS (1.0.0)
+  - unlock_detector (1.2.0):
+    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - unlock_detector (from `Flutter/ephemeral/.symlinks/plugins/unlock_detector/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
+  unlock_detector:
+    :path: Flutter/ephemeral/.symlinks/plugins/unlock_detector/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  unlock_detector: 32c966820074be887de5130716fac0a945665f46
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				14B0DED8161715B776443F8D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -322,6 +323,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		14B0DED8161715B776443F8D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -195,7 +195,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.2.0"
   vector_math:
     dependency: transitive
     description:

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <unlock_detector/unlock_detector_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UnlockDetectorPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UnlockDetectorPluginCApi"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  unlock_detector
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/lib/unlock_detector.dart
+++ b/lib/unlock_detector.dart
@@ -118,11 +118,8 @@ class UnlockDetector {
   static UnlockDetectorStatus? _currentStatus;
 
   static Duration? _idleTimeout;
-  static Timer? _idleTimer;
-
-  /// Registrant required by the Dart-only (web / desktop) platform
-  /// declarations. No-op — presence detection there is plain Dart.
-  static void registerWith() {}
+  static Timer? _idleTimer; // mobile / web: in-app inactivity timer
+  static Timer? _idlePollTimer; // desktop: OS system-idle poll
 
   /// Whether [initialize] has been called.
   static bool get isInitialized => _isInitialized;
@@ -146,10 +143,10 @@ class UnlockDetector {
   /// Starts detection. Safe to call multiple times — initializes only once.
   ///
   /// [idleTimeout] — when set, the status becomes [UnlockDetectorStatus.idle]
-  /// after the app has been in the foreground for this long without a
-  /// [reportActivity] call. Leave `null` to disable idle detection. When using
-  /// it, feed interaction via [reportActivity] or wrap your app in
-  /// [activityDetector].
+  /// after this much inactivity. On desktop (macOS, Windows, Linux) the idle
+  /// time is read system-wide from the OS automatically. On mobile and web,
+  /// feed interaction via [reportActivity] or wrap your app in
+  /// [activityDetector]. Leave `null` to disable idle detection.
   ///
   /// Throws [UnlockDetectorException] if initialization fails.
   static Future<void> initialize({Duration? idleTimeout}) async {
@@ -190,6 +187,11 @@ class UnlockDetector {
       if (state != null) {
         _onLifecycleStateChange(state);
       }
+
+      // On desktop, idle is read system-wide from the OS.
+      if (_idleTimeout != null && _isDesktop) {
+        _startIdlePolling();
+      }
     } on PlatformException catch (e) {
       throw UnlockDetectorException('Failed to initialize: ${e.message}', e);
     } catch (e) {
@@ -206,6 +208,8 @@ class UnlockDetector {
 
     _idleTimer?.cancel();
     _idleTimer = null;
+    _idlePollTimer?.cancel();
+    _idlePollTimer = null;
     await _nativeSubscription?.cancel();
     _nativeSubscription = null;
     _lifecycleListener?.dispose();
@@ -286,6 +290,14 @@ class UnlockDetector {
       defaultTargetPlatform == TargetPlatform.windows ||
       defaultTargetPlatform == TargetPlatform.linux;
 
+  /// Whether the app runs on a desktop OS (not web), where idle time can be
+  /// read system-wide from the operating system.
+  static bool get _isDesktop =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.macOS ||
+          defaultTargetPlatform == TargetPlatform.windows ||
+          defaultTargetPlatform == TargetPlatform.linux);
+
   static void _onLifecycleStateChange(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
@@ -311,9 +323,48 @@ class UnlockDetector {
 
   static void _armIdleTimer() {
     final timeout = _idleTimeout;
-    if (timeout == null) return;
+    // Desktop uses OS-level idle polling instead of an in-app timer.
+    if (timeout == null || _isDesktop) return;
     _idleTimer?.cancel();
     _idleTimer = Timer(timeout, () => _emit(UnlockDetectorStatus.idle));
+  }
+
+  /// Starts polling the OS for system-wide idle time (desktop only).
+  static void _startIdlePolling() {
+    final timeout = _idleTimeout;
+    if (timeout == null) return;
+    _idlePollTimer?.cancel();
+    final interval = timeout < const Duration(seconds: 60)
+        ? const Duration(seconds: 5)
+        : const Duration(seconds: 20);
+    _idlePollTimer = Timer.periodic(interval, (_) => _pollSystemIdle());
+    _pollSystemIdle();
+  }
+
+  /// Compares OS idle time against [_idleTimeout] and emits `idle` /
+  /// `foreground` accordingly. Only acts while the app is in the foreground.
+  static Future<void> _pollSystemIdle() async {
+    final timeout = _idleTimeout;
+    if (timeout == null) return;
+    final idleSeconds = await _systemIdleSeconds();
+    final isIdleNow = idleSeconds >= timeout.inSeconds;
+    if (isIdleNow && _currentStatus == UnlockDetectorStatus.foreground) {
+      _emit(UnlockDetectorStatus.idle);
+    } else if (!isIdleNow && _currentStatus == UnlockDetectorStatus.idle) {
+      _emit(UnlockDetectorStatus.foreground);
+    }
+  }
+
+  /// Seconds since the last system-wide input, from the native side.
+  static Future<int> _systemIdleSeconds() async {
+    try {
+      return await _methodChannel.invokeMethod<int>(
+            'get_system_idle_seconds',
+          ) ??
+          0;
+    } catch (_) {
+      return 0;
+    }
   }
 
   static void _emit(UnlockDetectorStatus status) {

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,0 +1,56 @@
+# The Flutter tooling requires that developers have CMake 3.10 or later
+# installed. You should not increase this version, as doing so will cause
+# the plugin to fail to compile for some customers of the plugin.
+cmake_minimum_required(VERSION 3.10)
+
+# Project-level configuration.
+set(PROJECT_NAME "unlock_detector")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# This value is used when generating builds using this plugin, so it must
+# not be changed.
+set(PLUGIN_NAME "unlock_detector_plugin")
+
+# Any new source files that you add to the plugin should be added here.
+list(APPEND PLUGIN_SOURCES
+  "unlock_detector_plugin.cc"
+)
+
+# Define the plugin library target. Its name must not be changed (see comment
+# on PLUGIN_NAME above).
+add_library(${PLUGIN_NAME} SHARED
+  ${PLUGIN_SOURCES}
+)
+
+# Apply a standard set of build settings that are configured in the
+# application-level CMakeLists.txt. This can be removed for plugins that want
+# full control over build settings.
+apply_standard_settings(${PLUGIN_NAME})
+
+# Symbols are hidden by default to reduce the chance of accidental conflicts
+# between plugins. This should not be removed; any symbols that should be
+# exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+
+# Source include directories and library dependencies. Add any plugin-specific
+# dependencies here.
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+
+# X11 screensaver extension — used to read the system-wide idle time.
+# Requires the libxss-dev (libxss) development package to be installed.
+find_package(X11 REQUIRED)
+target_include_directories(${PLUGIN_NAME} PRIVATE ${X11_INCLUDE_DIR})
+target_link_libraries(${PLUGIN_NAME} PRIVATE ${X11_LIBRARIES} ${X11_Xss_LIB})
+
+# List of absolute paths to libraries that should be bundled with the plugin.
+# This list could contain prebuilt libraries, or libraries created by an
+# external build triggered from this build file.
+set(unlock_detector_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/linux/include/unlock_detector/unlock_detector_plugin.h
+++ b/linux/include/unlock_detector/unlock_detector_plugin.h
@@ -1,0 +1,26 @@
+#ifndef FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_H_
+#define FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+typedef struct _UnlockDetectorPlugin UnlockDetectorPlugin;
+typedef struct {
+  GObjectClass parent_class;
+} UnlockDetectorPluginClass;
+
+FLUTTER_PLUGIN_EXPORT GType unlock_detector_plugin_get_type();
+
+FLUTTER_PLUGIN_EXPORT void unlock_detector_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar);
+
+G_END_DECLS
+
+#endif  // FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_H_

--- a/linux/unlock_detector_plugin.cc
+++ b/linux/unlock_detector_plugin.cc
@@ -1,0 +1,88 @@
+#include "include/unlock_detector/unlock_detector_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/scrnsaver.h>
+
+#include <cstring>
+
+#include "unlock_detector_plugin_private.h"
+
+#define UNLOCK_DETECTOR_PLUGIN(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), unlock_detector_plugin_get_type(), \
+                              UnlockDetectorPlugin))
+
+struct _UnlockDetectorPlugin {
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE(UnlockDetectorPlugin, unlock_detector_plugin, g_object_get_type())
+
+// Called when a method call is received from Flutter.
+static void unlock_detector_plugin_handle_method_call(
+    UnlockDetectorPlugin* self,
+    FlMethodCall* method_call) {
+  g_autoptr(FlMethodResponse) response = nullptr;
+
+  const gchar* method = fl_method_call_get_name(method_call);
+
+  if (strcmp(method, "get_system_idle_seconds") == 0) {
+    response = get_system_idle_seconds();
+  } else {
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
+
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+// Seconds since the last system-wide input, via the X11 screensaver extension.
+// Returns 0 when X11 is unavailable (e.g. a pure Wayland session).
+FlMethodResponse* get_system_idle_seconds() {
+  int64_t seconds = 0;
+  Display* display = XOpenDisplay(nullptr);
+  if (display != nullptr) {
+    XScreenSaverInfo* info = XScreenSaverAllocInfo();
+    if (info != nullptr) {
+      if (XScreenSaverQueryInfo(display, DefaultRootWindow(display), info)) {
+        seconds = static_cast<int64_t>(info->idle) / 1000;
+      }
+      XFree(info);
+    }
+    XCloseDisplay(display);
+  }
+  g_autoptr(FlValue) result = fl_value_new_int(seconds);
+  return FL_METHOD_RESPONSE(fl_method_success_response_new(result));
+}
+
+static void unlock_detector_plugin_dispose(GObject* object) {
+  G_OBJECT_CLASS(unlock_detector_plugin_parent_class)->dispose(object);
+}
+
+static void unlock_detector_plugin_class_init(UnlockDetectorPluginClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = unlock_detector_plugin_dispose;
+}
+
+static void unlock_detector_plugin_init(UnlockDetectorPlugin* self) {}
+
+static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+                           gpointer user_data) {
+  UnlockDetectorPlugin* plugin = UNLOCK_DETECTOR_PLUGIN(user_data);
+  unlock_detector_plugin_handle_method_call(plugin, method_call);
+}
+
+void unlock_detector_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
+  UnlockDetectorPlugin* plugin = UNLOCK_DETECTOR_PLUGIN(
+      g_object_new(unlock_detector_plugin_get_type(), nullptr));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) channel =
+      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
+                            "unlock_detector",
+                            FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(channel, method_call_cb,
+                                            g_object_ref(plugin),
+                                            g_object_unref);
+
+  g_object_unref(plugin);
+}

--- a/linux/unlock_detector_plugin_private.h
+++ b/linux/unlock_detector_plugin_private.h
@@ -1,0 +1,6 @@
+#include <flutter_linux/flutter_linux.h>
+
+#include "include/unlock_detector/unlock_detector_plugin.h"
+
+// Handles the get_system_idle_seconds method call.
+FlMethodResponse *get_system_idle_seconds();

--- a/macos/unlock_detector.podspec
+++ b/macos/unlock_detector.podspec
@@ -5,24 +5,23 @@
 Pod::Spec.new do |s|
   s.name             = 'unlock_detector'
   s.version          = '1.2.0'
-  s.summary          = 'Flutter plugin for detecting device lock/unlock and app foreground/background events.'
+  s.summary          = 'Flutter plugin for foreground/background, idle and lock/unlock detection.'
   s.description      = <<-DESC
-A Flutter plugin that detects device lock/unlock and app foreground/background
-transitions — useful for user presence (online/offline) tracking.
+A Flutter plugin that detects app foreground/background, idle, and device
+lock/unlock — for user online/offline presence.
                        DESC
   s.homepage         = 'https://github.com/mustafa-707/unlock_detector'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'mustafa-707' => 'https://github.com/mustafa-707' }
-  s.source           = { :path => '.' }
-  s.source_files     = 'unlock_detector/Sources/unlock_detector/**/*.swift'
-  s.resource_bundles = { 'unlock_detector_privacy' => ['unlock_detector/Sources/unlock_detector/PrivacyInfo.xcprivacy'] }
-  s.dependency 'Flutter'
-  s.platform = :ios, '13.0'
-  s.swift_version = '5.9'
 
-  s.pod_target_xcconfig = {
-    'DEFINES_MODULE' => 'YES',
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-  }
-  s.ios.deployment_target = '13.0'
+  s.source           = { :path => '.' }
+  s.source_files = 'unlock_detector/Sources/unlock_detector/**/*'
+  s.resource_bundles = { 'unlock_detector_privacy' => ['unlock_detector/Sources/unlock_detector/PrivacyInfo.xcprivacy'] }
+
+  s.dependency 'FlutterMacOS'
+  s.frameworks = 'IOKit'
+
+  s.platform = :osx, '10.15'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.swift_version = '5.0'
 end

--- a/macos/unlock_detector/Package.swift
+++ b/macos/unlock_detector/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "unlock_detector",
+    platforms: [
+        .macOS("10.15")
+    ],
+    products: [
+        .library(name: "unlock-detector", targets: ["unlock_detector"])
+    ],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
+    targets: [
+        .target(
+            name: "unlock_detector",
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
+            resources: [
+                .process("PrivacyInfo.xcprivacy")
+            ],
+            linkerSettings: [
+                .linkedFramework("IOKit")
+            ]
+        )
+    ]
+)

--- a/macos/unlock_detector/Sources/unlock_detector/PrivacyInfo.xcprivacy
+++ b/macos/unlock_detector/Sources/unlock_detector/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/macos/unlock_detector/Sources/unlock_detector/UnlockDetectorPlugin.swift
+++ b/macos/unlock_detector/Sources/unlock_detector/UnlockDetectorPlugin.swift
@@ -1,0 +1,50 @@
+import Cocoa
+import FlutterMacOS
+import IOKit
+
+/// macOS implementation of `unlock_detector`.
+///
+/// Provides system-wide idle time. Foreground/background (window focus) is
+/// handled in Dart via the Flutter app lifecycle.
+public class UnlockDetectorPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: "unlock_detector", binaryMessenger: registrar.messenger)
+    let instance = UnlockDetectorPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "get_system_idle_seconds":
+      result(systemIdleSeconds())
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  /// Seconds since the last system-wide keyboard or mouse input, read from the
+  /// IOKit HID system. Returns 0 if it cannot be determined.
+  private func systemIdleSeconds() -> Int {
+    var iterator: io_iterator_t = 0
+    guard IOServiceGetMatchingServices(
+      kIOMasterPortDefault,
+      IOServiceMatching("IOHIDSystem"),
+      &iterator
+    ) == KERN_SUCCESS else {
+      return 0
+    }
+    defer { IOObjectRelease(iterator) }
+
+    let entry = IOIteratorNext(iterator)
+    guard entry != 0 else { return 0 }
+    defer { IOObjectRelease(entry) }
+
+    var properties: Unmanaged<CFMutableDictionary>?
+    guard IORegistryEntryCreateCFProperties(entry, &properties, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+          let dict = properties?.takeRetainedValue() as? [String: Any],
+          let idleNanos = dict["HIDIdleTime"] as? Int64 else {
+      return 0
+    }
+    return Int(idleNanos / 1_000_000_000)
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: unlock_detector
 description: "A Flutter plugin to detect device lock/unlock and app foreground/background events for user online/offline presence."
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/mustafa-707/unlock_detector
 issue_tracker: https://github.com/mustafa-707/unlock_detector/issues
 
@@ -12,7 +12,7 @@ topics:
   - foreground
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.0.0"
 
 dependencies:
@@ -36,8 +36,8 @@ flutter:
         pluginClass: UnlockDetectorWeb
         fileName: unlock_detector_web.dart
       macos:
-        dartPluginClass: UnlockDetector
+        pluginClass: UnlockDetectorPlugin
       windows:
-        dartPluginClass: UnlockDetector
+        pluginClass: UnlockDetectorPluginCApi
       linux:
-        dartPluginClass: UnlockDetector
+        pluginClass: UnlockDetectorPlugin

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,0 +1,17 @@
+flutter/
+
+# Visual Studio user-specific files.
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Visual Studio build-related files.
+x64/
+x86/
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!*.[Cc]ache/

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,0 +1,57 @@
+# The Flutter tooling requires that developers have a version of Visual Studio
+# installed that includes CMake 3.14 or later. You should not increase this
+# version, as doing so will cause the plugin to fail to compile for some
+# customers of the plugin.
+cmake_minimum_required(VERSION 3.14)
+
+# Project-level configuration.
+set(PROJECT_NAME "unlock_detector")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(VERSION 3.14...3.25)
+
+# This value is used when generating builds using this plugin, so it must
+# not be changed
+set(PLUGIN_NAME "unlock_detector_plugin")
+
+# Any new source files that you add to the plugin should be added here.
+list(APPEND PLUGIN_SOURCES
+  "unlock_detector_plugin.cpp"
+  "unlock_detector_plugin.h"
+)
+
+# Define the plugin library target. Its name must not be changed (see comment
+# on PLUGIN_NAME above).
+add_library(${PLUGIN_NAME} SHARED
+  "include/unlock_detector/unlock_detector_plugin_c_api.h"
+  "unlock_detector_plugin_c_api.cpp"
+  ${PLUGIN_SOURCES}
+)
+
+# Apply a standard set of build settings that are configured in the
+# application-level CMakeLists.txt. This can be removed for plugins that want
+# full control over build settings.
+apply_standard_settings(${PLUGIN_NAME})
+
+# Symbols are hidden by default to reduce the chance of accidental conflicts
+# between plugins. This should not be removed; any symbols that should be
+# exported should be explicitly exported with the FLUTTER_PLUGIN_EXPORT macro.
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+
+# Source include directories and library dependencies. Add any plugin-specific
+# dependencies here.
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+
+# List of absolute paths to libraries that should be bundled with the plugin.
+# This list could contain prebuilt libraries, or libraries created by an
+# external build triggered from this build file.
+set(unlock_detector_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/windows/include/unlock_detector/unlock_detector_plugin_c_api.h
+++ b/windows/include/unlock_detector/unlock_detector_plugin_c_api.h
@@ -1,0 +1,23 @@
+#ifndef FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_C_API_H_
+#define FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_C_API_H_
+
+#include <flutter_plugin_registrar.h>
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void UnlockDetectorPluginCApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_C_API_H_

--- a/windows/unlock_detector_plugin.cpp
+++ b/windows/unlock_detector_plugin.cpp
@@ -1,0 +1,57 @@
+#include "unlock_detector_plugin.h"
+
+// This must be included before many other Windows headers.
+#include <windows.h>
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+#include <flutter/standard_method_codec.h>
+
+#include <memory>
+
+namespace unlock_detector {
+
+// static
+void UnlockDetectorPlugin::RegisterWithRegistrar(
+    flutter::PluginRegistrarWindows *registrar) {
+  auto channel =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          registrar->messenger(), "unlock_detector",
+          &flutter::StandardMethodCodec::GetInstance());
+
+  auto plugin = std::make_unique<UnlockDetectorPlugin>();
+
+  channel->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto &call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+
+  registrar->AddPlugin(std::move(plugin));
+}
+
+UnlockDetectorPlugin::UnlockDetectorPlugin() {}
+
+UnlockDetectorPlugin::~UnlockDetectorPlugin() {}
+
+// Seconds since the last system-wide keyboard or mouse input.
+static int SystemIdleSeconds() {
+  LASTINPUTINFO last_input;
+  last_input.cbSize = sizeof(LASTINPUTINFO);
+  if (!GetLastInputInfo(&last_input)) {
+    return 0;
+  }
+  DWORD idle_ms = GetTickCount() - last_input.dwTime;
+  return static_cast<int>(idle_ms / 1000);
+}
+
+void UnlockDetectorPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue> &method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  if (method_call.method_name().compare("get_system_idle_seconds") == 0) {
+    result->Success(flutter::EncodableValue(SystemIdleSeconds()));
+  } else {
+    result->NotImplemented();
+  }
+}
+
+}  // namespace unlock_detector

--- a/windows/unlock_detector_plugin.h
+++ b/windows/unlock_detector_plugin.h
@@ -1,0 +1,31 @@
+#ifndef FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_H_
+#define FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_H_
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+
+#include <memory>
+
+namespace unlock_detector {
+
+class UnlockDetectorPlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+
+  UnlockDetectorPlugin();
+
+  virtual ~UnlockDetectorPlugin();
+
+  // Disallow copy and assign.
+  UnlockDetectorPlugin(const UnlockDetectorPlugin&) = delete;
+  UnlockDetectorPlugin& operator=(const UnlockDetectorPlugin&) = delete;
+
+  // Called when a method is called on this plugin's channel from Dart.
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue> &method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+};
+
+}  // namespace unlock_detector
+
+#endif  // FLUTTER_PLUGIN_UNLOCK_DETECTOR_PLUGIN_H_

--- a/windows/unlock_detector_plugin_c_api.cpp
+++ b/windows/unlock_detector_plugin_c_api.cpp
@@ -1,0 +1,12 @@
+#include "include/unlock_detector/unlock_detector_plugin_c_api.h"
+
+#include <flutter/plugin_registrar_windows.h>
+
+#include "unlock_detector_plugin.h"
+
+void UnlockDetectorPluginCApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  unlock_detector::UnlockDetectorPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+}


### PR DESCRIPTION
## Summary

Adds native **macOS, Windows and Linux** plugin implementations with **system-wide idle detection** — and the desktop platform folders.

## Features

- **System-wide idle** — with `initialize(idleTimeout:)`, the `idle` status follows the OS idle time on desktop (time since *any* keyboard/mouse input). No `reportActivity()` needed there.
  - macOS: IOKit HID idle time
  - Windows: `GetLastInputInfo`
  - Linux: X11 `XScreenSaver` extension (requires `libxss-dev`)
- All six platforms now declared with native `pluginClass` implementations.
- macOS: IOKit framework linked, privacy manifest bundled, podspec/Package.swift metadata fixed.
- Removed `flutter create` scaffold artifacts (federated stubs, generated tests, duplicate Kotlin-DSL gradle files).

## Verification

- ✅ Android, iOS, Web, **macOS** all build; `dart analyze` / `dart format` clean.
- ⚠️ **Windows & Linux native code is not compile-tested** here — uses standard OS APIs; verify with `flutter build windows` / `flutter build linux`. Published to gather user feedback.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)